### PR TITLE
M3U8 bug fix

### DIFF
--- a/plugin/letv.m
+++ b/plugin/letv.m
@@ -359,7 +359,13 @@ int letv_getTKey(int time){
         const char *result = letv_decryptM3U8([m3u8_data bytes],[m3u8_data length]);
         NSData *data = [NSData dataWithBytes:result length:[m3u8_data length]];
         NSString *path = [NSString stringWithFormat:@"%@letv_%@_%@.m3u8",NSTemporaryDirectory(),evt_videoid,sel_streamid];
-        [data writeToFile:path atomically:YES];
+        NSString *string = [[NSString alloc] initWithData:data encoding:NSASCIIStringEncoding];
+        NSString *strTo = @"#EXT-X-ENDLIST";
+        if ([string containsString:strTo]) {
+            NSRange range = [string rangeOfString:strTo];
+            string = [string substringToIndex:range.location + strTo.length];
+        }
+       [string writeToFile:path atomically:YES encoding:NSUTF8StringEncoding error:nil];
         
         sel_addr = [[NSURL URLWithString:path] absoluteString];
         [self setText:@"解析成功"];


### PR DESCRIPTION
生成的 M3U8 文件在 #EXT-X-ENDLIST 后有一行乱码，某些播放器拖动的时候会卡住
